### PR TITLE
Group登録時のエラー解消

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   validates :name, presence: true, uniqueness: true
-  # validates :password, presence: true, length: {minimum: 8 }
+  validates :password, presence: true, length: {minimum: 8 },on: :create
 
   has_many :group_users
   has_many :groups, through: :group_users

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module AppTaskManage
       g.test_framework false
     end
     config.i18n.default_locale = :ja
+    config.logger = Logger.new(STDOUT)
   end
 end


### PR DESCRIPTION
 # What
group登録時にuserモデルに指定したバリデーションが原因でエラーが発生しました。
その解消のため修正を行いました。

 # Why
password登録時に8文字以上必須のバリデーションがgroup登録でエラーの原因となっており、両記述とも本アプリには必要のため、バリデーションに新たにオプションを追加しました。